### PR TITLE
No retries for not found 404

### DIFF
--- a/internal/app/helper/api/league-api-helper.go
+++ b/internal/app/helper/api/league-api-helper.go
@@ -97,13 +97,16 @@ func makeRequest(url string) (*http.Response, error) {
 		log.Printf("Request URL: %s", url)
 		log.Printf("Response: %s", resp.Status)
 		log.Printf("Request failed with status code: %d", resp.StatusCode)
+		if resp.StatusCode == 404 {
+			return resp, fmt.Errorf("not found")
+		}
 		if resp.StatusCode == 429 && retries == 0 {
 			resp.Body.Close()
 			time.Sleep(10 * time.Second)
 			log.Println("Rate limit exceeded, waiting 10 seconds...")
 			continue
 		}
-		if err != nil || resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
+		if err != nil || resp.StatusCode != http.StatusOK {
 			if retries == 1 {
 				return nil, fmt.Errorf("failed to make request after retries: %w", err)
 			}


### PR DESCRIPTION
This pull request includes an important change to the `makeRequest` function in the `league-api-helper.go` file to handle a specific HTTP status code more appropriately.

Error handling improvement:

* [`internal/app/helper/api/league-api-helper.go`](diffhunk://#diff-ed9bf6f579c224bf3cdd379c3c8abfe323b8029f2a7c4b1592a18f2771924208R100-R102): Added a conditional check to return a "not found" error if the HTTP response status code is 404.