### PR TITLE
feat: remove unnecessary logging in makeRequest function

### DIFF
--- a/internal/app/helper/api/league-api-helper.go
+++ b/internal/app/helper/api/league-api-helper.go
@@ -94,9 +94,6 @@ func makeRequest(url string) (*http.Response, error) {
 	for retries := 0; retries < 2; retries++ {
 		waitForRateLimiters()
 		resp, err := http.Get(url)
-		log.Printf("Request URL: %s", url)
-		log.Printf("Response: %s", resp.Status)
-		log.Printf("Request failed with status code: %d", resp.StatusCode)
 		if resp.StatusCode == 404 {
 			return resp, fmt.Errorf("not found")
 		}


### PR DESCRIPTION
This pull request includes a small change to the `internal/app/helper/api/league-api-helper.go` file. The change removes unnecessary logging statements from the `makeRequest` function to clean up the code and reduce noise in the logs.

* [`internal/app/helper/api/league-api-helper.go`](diffhunk://#diff-ed9bf6f579c224bf3cdd379c3c8abfe323b8029f2a7c4b1592a18f2771924208L97-L99): Removed logging statements for request URL, response status, and status code in the `makeRequest` function.