### PR TITLE
Improve rate limit waiting mechanism

### DIFF
--- a/internal/app/helper/api/league-api-helper.go
+++ b/internal/app/helper/api/league-api-helper.go
@@ -74,7 +74,7 @@ func LoadEnv() error {
 
 func waitForRateLimiters() {
 	for !rateLimiterPerSecond.Check() || !rateLimiterPer2Minutes.Check() {
-		time.Sleep(time.Second)
+		time.Sleep(time.Duration(int(rateLimiterPerSecond.GetInterval().Seconds())/rateLimiterPerSecond.GetMaxTokens()*1000) * time.Millisecond)
 	}
 	rateLimiterPer2Minutes.Allow()
 	rateLimiterPerSecond.Allow()

--- a/internal/app/helper/api/rate_limit.go
+++ b/internal/app/helper/api/rate_limit.go
@@ -73,6 +73,14 @@ func (rl *RateLimiter) cleanup(now time.Time) {
 	logger.Logger.Debug("Tokens cleaned up", zap.Int("remainingTokens", len(rl.requests)))
 }
 
+func (rl *RateLimiter) GetInterval() time.Duration {
+	return rateLimiterPerSecond.interval
+}
+
+func (rl *RateLimiter) GetMaxTokens() int {
+	return rateLimiterPerSecond.maxTokens
+}
+
 func getEnvAsInt(name string, defaultValue int) int {
 	valueStr := os.Getenv(name)
 	if value, err := strconv.Atoi(valueStr); err == nil {


### PR DESCRIPTION
Adjust the waiting time for rate limiters to be based on the average time it should take for a token to be consumed, enhancing the efficiency of the rate limiting process.