### PR TITLE
Normalize Rate Limiter to One Request Per Second

### DIFF
--- a/internal/app/helper/api/league-api-helper.go
+++ b/internal/app/helper/api/league-api-helper.go
@@ -74,7 +74,7 @@ func LoadEnv() error {
 
 func waitForRateLimiters() {
 	for !rateLimiterPerSecond.Check() || !rateLimiterPer2Minutes.Check() {
-		time.Sleep(time.Duration(int(rateLimiterPerSecond.GetInterval().Seconds())/rateLimiterPerSecond.GetMaxTokens()*1000) * time.Millisecond)
+		time.Sleep(time.Duration(int(rateLimiterPerSecond.GetInterval().Seconds())/rateLimiterPerSecond.GetMaxTokens()*100) * time.Millisecond)
 	}
 	rateLimiterPer2Minutes.Allow()
 	rateLimiterPerSecond.Allow()

--- a/internal/app/helper/api/rate_limit.go
+++ b/internal/app/helper/api/rate_limit.go
@@ -89,5 +89,5 @@ func getEnvAsInt(name string, defaultValue int) int {
 	return defaultValue
 }
 
-var rateLimiterPerSecond = NewRateLimiter(getEnvAsInt("API_RATE_LIMIT_SECOND", 5), time.Second)        // 8 requests per second
-var rateLimiterPer2Minutes = NewRateLimiter(getEnvAsInt("API_RATE_LIMIT_2_MINUTE", 50), 2*time.Minute) // 80 requests per 2 minutes
+var rateLimiterPerSecond = NewRateLimiter(1, time.Duration(1/getEnvAsInt("API_RATE_LIMIT_SECOND", 5)*1000)*time.Millisecond)
+var rateLimiterPer2Minutes = NewRateLimiter(getEnvAsInt("API_RATE_LIMIT_2_MINUTE", 50), 2*time.Minute)


### PR DESCRIPTION
Adjust the rate limiter configuration to ensure it consistently allows one request per amount of time, which would lead to the per env given rate of api calls per Second.
e.g. 10/s -> 1/100ms
50/s -> 1/20ms

This slows down the application, by the right amount to be very consistent in API Calls and predictable in Roundtimes.